### PR TITLE
STR-157 add support for CL rpcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "simd-json",
  "sled",
  "systemd",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -1756,18 +1757,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tungstenite = "0.20.1"
 tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 futures-util = "0.3.29"
 systemd = { version = "0.10.0", optional = true }
+thiserror = "1.0.64"
 
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users

--- a/example_config.toml
+++ b/example_config.toml
@@ -70,3 +70,12 @@ ws_url = "wss://eth.merkle.io"
 max_consecutive = 150
 # Max amount of queries per second.
 max_per_second = 200
+
+[strata]
+url = "https://strata.merkle.io"
+ws_url = "wss://strata.merkle.io"
+# The maximum amount of time we can use this rpc in a row.
+max_consecutive = 150
+# Max amount of queries per second.
+max_per_second = 200
+group = "strata"

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -17,7 +17,10 @@ use crate::{
     log_wrn,
     no_rpc_available,
     print_cache_error,
-    rpc::types::Rpc,
+    rpc::types::{
+        RouteGroup,
+        Rpc,
+    },
     rpc_response,
     timed_out,
     websocket::{
@@ -239,6 +242,11 @@ macro_rules! fetch_from_rpc {
         // Kinda jank but set the id back to what it was before
         $tx["id"] = $id.into();
 
+        let route_group = $tx["method"]
+            .as_str()
+            .map(RouteGroup::from_method_name)
+            .unwrap_or_default();
+
         // Loop until we get a response
         let mut rx;
         let mut retries = 0;
@@ -247,7 +255,7 @@ macro_rules! fetch_from_rpc {
             let mut rpc;
             {
                 let mut rpc_list = $rpc_list_rwlock.write().unwrap();
-                (rpc, $rpc_position) = pick(&mut rpc_list);
+                (rpc, $rpc_position) = pick(&mut rpc_list, &route_group);
             }
             log_info!("Forwarding to: {}", rpc.name);
 

--- a/src/balancer/selection/select.rs
+++ b/src/balancer/selection/select.rs
@@ -35,7 +35,7 @@ pub fn pick(list: &mut [Rpc], route_group: &RouteGroup) -> (Rpc, Option<usize>) 
         .collect::<Vec<_>>();
     // If len is 1, return the only element
     if filtered_list.len() == 1 {
-        return (list[0].clone(), Some(0));
+        return (filtered_list[0].inner().clone(), Some(filtered_list[0].idx));
     } else if filtered_list.is_empty() {
         return (Rpc::default(), None);
     }
@@ -236,5 +236,30 @@ mod tests {
         println!("rpc index: {:?}", index);
         assert_eq!(rpc.status.latency, 7.0);
         assert_eq!(index, Some(1));
+    }
+
+    #[test]
+    fn test_pick_correct_group() {
+        let mut rpc_list = vec![
+            Rpc::default().with_route_group(RouteGroup::StrataCL),
+            Rpc::default().with_route_group(RouteGroup::Ethereum),
+        ];
+
+        let (rpc, _) = pick(&mut rpc_list, &RouteGroup::StrataCL);
+        assert_eq!(rpc.group, RouteGroup::StrataCL);
+
+        let (rpc, _) = pick(&mut rpc_list, &RouteGroup::Ethereum);
+        assert_eq!(rpc.group, RouteGroup::Ethereum);
+
+        let mut rpc_list = vec![
+            Rpc::default().with_route_group(RouteGroup::Ethereum),
+            Rpc::default().with_route_group(RouteGroup::Ethereum),
+        ];
+
+        let (_, index) = pick(&mut rpc_list, &RouteGroup::StrataCL);
+        assert_eq!(index, None);
+
+        let (rpc, _) = pick(&mut rpc_list, &RouteGroup::Ethereum);
+        assert_eq!(rpc.group, RouteGroup::Ethereum);
     }
 }

--- a/src/balancer/selection/select.rs
+++ b/src/balancer/selection/select.rs
@@ -1,25 +1,57 @@
-use crate::Rpc;
+use crate::{
+    rpc::types::RouteGroup,
+    Rpc,
+};
 use std::time::SystemTime;
 
+#[derive(Debug)]
+pub struct RpcIndexed<'a> {
+    rpc: &'a mut Rpc,
+    idx: usize,
+}
+
+impl<'a> RpcIndexed<'a> {
+    fn inner(&self) -> &Rpc {
+        self.rpc
+    }
+
+    fn inner_mut(&mut self) -> &mut Rpc {
+        self.rpc
+    }
+}
+
 // Generic entry point fn to select the next rpc and return its position
-pub fn pick(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
+pub fn pick(list: &mut [Rpc], route_group: &RouteGroup) -> (Rpc, Option<usize>) {
+    let mut filtered_list = list
+        .iter_mut()
+        .enumerate()
+        .filter_map(|(idx, rpc)| {
+            if rpc.group == *route_group {
+                Some(RpcIndexed { rpc, idx })
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
     // If len is 1, return the only element
-    if list.len() == 1 {
+    if filtered_list.len() == 1 {
         return (list[0].clone(), Some(0));
-    } else if list.is_empty() {
+    } else if filtered_list.is_empty() {
         return (Rpc::default(), None);
     }
 
-    algo(list)
+    let picked_idx = algo(&mut filtered_list);
+    let picked = &filtered_list[picked_idx];
+    (picked.inner().clone(), Some(picked.idx))
 }
 
 // Sorting algo
-pub fn argsort(data: &[Rpc]) -> Vec<usize> {
+pub fn argsort(data: &[RpcIndexed]) -> Vec<usize> {
     let mut indices = (0..data.len()).collect::<Vec<usize>>();
 
     // Use sort_by_cached_key with a closure that compares latency
     // Uses pdqsort and does not allocate so should be fast
-    indices.sort_unstable_by_key(|&index| data[index].status.latency as u64);
+    indices.sort_unstable_by_key(|&index| data[index].inner().status.latency as u64);
 
     indices
 }
@@ -35,7 +67,7 @@ pub fn argsort(data: &[Rpc]) -> Vec<usize> {
     not(feature = "selection-random"),
     not(feature = "old-weighted-round-robin"),
 ))]
-fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
+fn algo(list: &mut [RpcIndexed]) -> usize {
     // Sort by latency
     let indices = argsort(list);
 
@@ -51,52 +83,52 @@ fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     let mut choice = indices[0];
     let mut choice_consecutive = 0;
     for i in indices.iter().rev() {
-        if list[*i].max_consecutive > list[*i].consecutive
-            && (time - list[*i].last_used > list[*i].min_time_delta)
+        if list[*i].inner().max_consecutive > list[*i].inner().consecutive
+            && (time - list[*i].inner().last_used > list[*i].inner().min_time_delta)
         {
             choice = *i;
-            choice_consecutive = list[*i].consecutive;
+            choice_consecutive = list[*i].inner().consecutive;
         }
 
         // remove consecutive
-        list[*i].consecutive = 0;
+        list[*i].inner_mut().consecutive = 0;
     }
 
     // If no RPC has been selected, fall back to the fastest RPC
-    list[choice].consecutive = choice_consecutive + 1;
-    list[choice].last_used = time;
-    (list[choice].clone(), Some(choice))
+    list[choice].inner_mut().consecutive = choice_consecutive + 1;
+    list[choice].inner_mut().last_used = time;
+    choice
 }
 
 #[cfg(all(
     feature = "selection-weighed-round-robin",
     feature = "selection-random"
 ))]
-fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
+fn algo(list: &mut [RpcIndexed]) -> usize {
     use rand::Rng;
 
     let mut rng = rand::thread_rng();
     let index = rng.gen_range(0..list.len());
-    (list[index].clone(), Some(index))
+    index
 }
 
 #[cfg(all(
     feature = "selection-weighed-round-robin",
     feature = "old-weighted-round-robin",
 ))]
-fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
+fn algo(list: &mut [RpcIndexed]) -> usize {
     // Sort by latency
     let indices = argsort(list);
 
     // Picks the second fastest one if the fastest one has maxed out
-    if list[indices[0]].max_consecutive <= list[indices[0]].consecutive {
-        list[indices[1]].consecutive = 1;
-        list[indices[0]].consecutive = 0;
-        return (list[indices[1]].clone(), Some(indices[1]));
+    if list[indices[0]].inner().max_consecutive <= list[indices[0]].inner().consecutive {
+        list[indices[1]].inner_mut().consecutive = 1;
+        list[indices[0]].inner_mut().consecutive = 0;
+        return indices[1];
     }
 
-    list[indices[0]].consecutive += 1;
-    (list[indices[0]].clone(), Some(indices[0]))
+    list[indices[0]].inner_mut().consecutive += 1;
+    indices[0]
 }
 
 // Tests
@@ -114,11 +146,16 @@ mod tests {
         rpc2.status.latency = 2.0;
         rpc3.status.latency = 3.0;
 
-        let v = vec![rpc2, rpc3, rpc1];
+        let mut v = vec![rpc2, rpc3, rpc1];
         let vx = v.clone();
-        let i = argsort(&v);
+        let vi = v
+            .iter_mut()
+            .enumerate()
+            .map(|(idx, rpc)| RpcIndexed { rpc, idx })
+            .collect::<Vec<_>>();
+        let i = argsort(&vi);
         assert_eq!(i, &[2, 0, 1]);
-        assert_eq!(v[0].get_url(), vx[0].get_url());
+        assert_eq!(vi[0].inner().get_url(), vx[0].get_url());
     }
 
     // Test picking the fastest RPC
@@ -144,21 +181,21 @@ mod tests {
 
         let mut rpc_list = vec![rpc1, rpc2, rpc3];
 
-        let (rpc, index) = pick(&mut rpc_list);
+        let (rpc, index) = pick(&mut rpc_list, &RouteGroup::default());
         println!("rpc: {:?}", rpc);
         assert_eq!(rpc.status.latency, 3.0);
         assert_eq!(index, Some(0));
 
         rpc_list[0].status.latency = 10000.0;
 
-        let (rpc, index) = pick(&mut rpc_list);
+        let (rpc, index) = pick(&mut rpc_list, &RouteGroup::default());
         println!("rpc index: {:?}", index);
         assert_eq!(rpc.status.latency, 5.0);
         assert_eq!(index, Some(2));
 
         rpc_list[2].status.latency = 100000.0;
 
-        let (rpc, index) = pick(&mut rpc_list);
+        let (rpc, index) = pick(&mut rpc_list, &RouteGroup::default());
         assert_eq!(rpc.status.latency, 7.0);
         assert_eq!(index, Some(1));
     }
@@ -189,13 +226,13 @@ mod tests {
         let mut rpc_list = vec![rpc1, rpc2, rpc3];
 
         // Pick rpc3 becauese rpc1 does not meet last used requirements
-        let (rpc, index) = pick(&mut rpc_list);
+        let (rpc, index) = pick(&mut rpc_list, &RouteGroup::default());
         println!("rpc: {:?}", rpc);
         assert_eq!(rpc.status.latency, 5.0);
         assert_eq!(index, Some(2));
 
         // pick rpc2 because rpc3 was just used
-        let (rpc, index) = pick(&mut rpc_list);
+        let (rpc, index) = pick(&mut rpc_list, &RouteGroup::default());
         println!("rpc index: {:?}", index);
         assert_eq!(rpc.status.latency, 7.0);
         assert_eq!(index, Some(1));

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -2,6 +2,7 @@ use crate::{
     config::setup::sort_by_latency,
     log_info,
     log_wrn,
+    rpc::types::RouteGroup,
     Rpc,
 };
 use clap::{
@@ -283,6 +284,9 @@ impl Settings {
             if table_name != "blutgang" && table_name != "sled" && table_name != "admin" {
                 let rpc_table = parsed_toml.get(table_name).unwrap().as_table().unwrap();
 
+                let group = rpc_table.get("group").and_then(|s| s.as_str());
+                let route_group = RouteGroup::from_config(group);
+
                 let max_consecutive = rpc_table
                     .get("max_consecutive")
                     .expect("\x1b[31mErr:\x1b[0m Missing max_consecutive from an RPC!")
@@ -328,7 +332,8 @@ impl Settings {
                     }
                 };
 
-                let rpc = Rpc::new(url, ws_url, max_consecutive, delta.into(), ma_length);
+                let rpc = Rpc::new(url, ws_url, max_consecutive, delta.into(), ma_length)
+                    .with_route_group(route_group);
                 rpc_list.push(rpc);
             }
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -285,7 +285,7 @@ impl Settings {
                 let rpc_table = parsed_toml.get(table_name).unwrap().as_table().unwrap();
 
                 let group = rpc_table.get("group").and_then(|s| s.as_str());
-                let route_group = RouteGroup::from_config(group);
+                let route_group = RouteGroup::from_config(group).unwrap();
 
                 let max_consecutive = rpc_table
                     .get("max_consecutive")

--- a/src/health/check.rs
+++ b/src/health/check.rs
@@ -3,27 +3,19 @@ use crate::{
         HealthState,
         LiveReadyUpdate,
         LiveReadyUpdateSnd,
-    },
-    health::{
+    }, health::{
         error::HealthError,
         safe_block::{
             get_safe_block,
             NamedBlocknumbers,
         },
-    },
-    log_info,
-    log_wrn,
-    websocket::{
+    }, log_info, log_wrn, rpc::types::RouteGroup, websocket::{
         subscription_manager::move_subscriptions,
         types::{
             WsChannelErr,
             WsconnMessage,
         },
-    },
-    IncomingResponse,
-    Rpc,
-    Settings,
-    SubscriptionData,
+    }, IncomingResponse, Rpc, Settings, SubscriptionData
 };
 
 use std::{
@@ -236,6 +228,11 @@ fn make_poverty(
 
     for head in heads {
         if head.reported_head < highest_head || head.is_syncing {
+            // skip head checks on alp rpc calls
+            if rpc_list_guard[head.rpc_list_index].group == RouteGroup::StrataCL {
+                continue;
+            }
+
             // Mark the RPC as erroring
             rpc_list_guard[head.rpc_list_index].status.is_erroring = true;
             log_wrn!(

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -50,7 +50,7 @@ impl RouteGroup {
 #[derive(Debug, Clone)]
 pub struct Rpc {
     pub name: String,           // sanitized name for appearing in logs
-    pub group: RouteGroup,
+    pub group: RouteGroup,      // rpc subsets
     url: String,                // url of the rpc we're forwarding requests to.
     client: Client,             // Reqwest client
     pub ws_url: Option<String>, // url of the websocket we're forwarding requests to.
@@ -165,6 +165,11 @@ impl Rpc {
 
     /// Request blocknumber and return its value
     pub async fn block_number(&self) -> Result<u64, crate::rpc::types::RpcError> {
+        // skip sync check on strata rpc
+        if self.group == RouteGroup::StrataCL {
+            return Ok(0);
+        }
+
         let request = json!({
             "method": "eth_blockNumber".to_string(),
             "params": serde_json::Value::Null,
@@ -180,6 +185,11 @@ impl Rpc {
 
     /// Returns the sync status. False if we're synced and following the head.
     pub async fn syncing(&self) -> Result<bool, crate::rpc::types::RpcError> {
+        // skip sync check on strata rpc
+        if self.group == RouteGroup::StrataCL {
+            return Ok(false);
+        }
+
         let request = json!({
             "method": "eth_syncing".to_string(),
             "params": serde_json::Value::Null,
@@ -195,6 +205,11 @@ impl Rpc {
 
     /// Get the latest finalized block
     pub async fn get_finalized_block(&self) -> Result<u64, crate::rpc::types::RpcError> {
+        // skip sync check on strata rpc
+        if self.group == RouteGroup::StrataCL {
+            return Ok(0);
+        }
+
         let request = json!({
             "method": "eth_getBlockByNumber".to_string(),
             "params": ["finalized", false],

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -10,7 +10,10 @@ use crate::{
     },
     log_err,
     log_info,
-    rpc::types::Rpc,
+    rpc::types::{
+        RouteGroup,
+        Rpc,
+    },
     websocket::{
         error::WsError,
         types::{
@@ -140,7 +143,12 @@ async fn handle_incoming_message(
             e.into_inner()
         });
 
-        match pick(&mut rpc_list_guard).1 {
+        let route_group = incoming["method"]
+            .as_str()
+            .map(RouteGroup::from_method_name)
+            .unwrap_or_default();
+
+        match pick(&mut rpc_list_guard, &route_group).1 {
             Some(position) => position,
             None => {
                 // Check if the incoming content is a subscription.


### PR DESCRIPTION
A bit hacky, but trying to keep changes minimal.
Allow calls to be routed to sub groups based on method name (only `alp_` prefix for now).
Will need to look into performance later.